### PR TITLE
Fixes for timezone parsing in iCal feeds

### DIFF
--- a/includes/class-wp-event-aggregator-ical_parser.php
+++ b/includes/class-wp-event-aggregator-ical_parser.php
@@ -342,6 +342,9 @@ class WP_Event_Aggregator_Ical_Parser {
                 }
 			}		
 		}
+		// Convert the source date/time from the source timezone to our wordpress timezone:
+		$start_time_local = $this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone);
+		$end_time_local = $this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone);
 
 		$xt_event = array(
 			'origin'          => 'ical',
@@ -349,8 +352,8 @@ class WP_Event_Aggregator_Ical_Parser {
 			'ID_ical_old'     => $uid_old,
 			'name'            => $post_title,
 			'description'     => $post_description,
-			'starttime_local' => $start_time,
-			'endtime_local'   => $end_time,
+			'starttime_local' => $start_time_local,
+			'endtime_local'   => $end_time_local,
 			'starttime'       => date('Ymd\THis', $start_time),
 			'endtime'         => date('Ymd\THis', $end_time),
 			'startime_utc'    => '',
@@ -544,4 +547,18 @@ class WP_Event_Aggregator_Ical_Parser {
             return $datetime;
         }
     }
+	public function convert_datetime_to_local_timezone($datetime, $source_timezone, $local_timezone)
+	{
+		if (empty($source_timezone)){
+			$source_timezone = 'UTC';
+		}
+		try {
+            $datetime = new DateTime( $datetime, new DateTimeZone($source_timezone));
+			$datetime->setTimezone(new DateTimeZone( $local_timezone ) );		
+            return $datetime->format( 'Y-m-d H:i:s' );
+        }
+        catch ( Exception $e ) {
+            return $datetime;
+        }
+	}
 }

--- a/includes/class-wp-event-aggregator-ical_parser.php
+++ b/includes/class-wp-event-aggregator-ical_parser.php
@@ -342,6 +342,7 @@ class WP_Event_Aggregator_Ical_Parser {
                 }
 			}		
 		}
+
 		// Convert the source date/time from the source timezone to our wordpress timezone:
 		$start_time_local = strtotime($this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone));
 		$end_time_local = strtotime($this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone));
@@ -546,19 +547,30 @@ class WP_Event_Aggregator_Ical_Parser {
         catch ( Exception $e ) {
             return $datetime;
         }
-    }
+	}
+
+	/**
+	* Convert date in given source timezone into the local timezone provided.
+	* Assumes that the 'local' timezone will be the local timezone of the computer or wordpress, whatever is set.
+	* 
+	* @param string $datetime           Date string to convert to the local timezone
+	* @param string $source_timezone    Timezone in which the datetime is located. Defaults to UTC
+	* @param string $local_timezone 	The local timezone of the wordpress site or server, into which we're converting.
+	* 
+	* @return DateTime
+	*/
 	public function convert_datetime_to_local_timezone($datetime, $source_timezone, $local_timezone)
 	{
-		if (empty($source_timezone)){
-			$source_timezone = 'UTC';
-		}
-		try {
+        if (empty($source_timezone)){
+            $source_timezone = 'UTC';
+        }
+        try {
             $datetime = new DateTime( $datetime, new DateTimeZone($source_timezone));
-			$datetime->setTimezone(new DateTimeZone( $local_timezone ) );		
-            return $datetime->format( 'Y-m-d H:i:s' );
+            $datetime->setTimezone(new DateTimeZone( $local_timezone ) );		
+			return $datetime->format( 'Y-m-d H:i:s' );
         }
         catch ( Exception $e ) {
             return $datetime;
         }
-	}
+    }
 }

--- a/includes/class-wp-event-aggregator-ical_parser.php
+++ b/includes/class-wp-event-aggregator-ical_parser.php
@@ -343,8 +343,8 @@ class WP_Event_Aggregator_Ical_Parser {
 			}		
 		}
 		// Convert the source date/time from the source timezone to our wordpress timezone:
-		$start_time_local = $this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone);
-		$end_time_local = $this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone);
+		$start_time_local = strtotime($this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone));
+		$end_time_local = strtotime($this->convert_datetime_to_local_timezone($start, $calendar_timezone, $wordpress_timezone));
 
 		$xt_event = array(
 			'origin'          => 'ical',


### PR DESCRIPTION
Our site was having issues with timezones (daylight saving time) because the event aggregator plugin wasn't normalising timezones, meaning events appeared an hour offset from where they should have done on our site.

I had to apply these fixes to get it working. I haven't tested them exhaustively outside our specific use case, but I don't see why they shouldn't work in general, possibly with a little tweaking.